### PR TITLE
Add subscript overrides to return AnyObject

### DIFF
--- a/LumaJSON.swift
+++ b/LumaJSON.swift
@@ -14,19 +14,24 @@ class LumaJSONObject: Printable {
     
     subscript(index: Int) -> LumaJSONObject? {
         get {
-            if let val = value as? NSArray {
-                return LumaJSONObject(val[index])
-            }
-            return nil
+            return (value as? [AnyObject]).map { LumaJSONObject($0[index]) }
         }
     }
     subscript(key: String) -> LumaJSONObject? {
         get {
-            
-            if let val = value as? NSDictionary {
-                return LumaJSONObject(val[key])
-            }
-            return nil
+            return (value as? NSDictionary).map { LumaJSONObject($0[key]) }
+        }
+    }
+    
+    subscript(key: String) -> AnyObject? {
+        get {
+            return self[key]?.value
+        }
+    }
+    
+    subscript(key: Int) -> AnyObject? {
+        get {
+            return self[key]?.value
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ Given a JSON structure such as:
 LumaJSON will recognize this as having a root NSDictionary node with three keys:
 user, friend_ids, and alert_message
 
-These can be accessed using a subscript, and will return an Optional LumaJSONObject.
-
-The value can be retrieved using the value property, which you are responsible for casting to the appropriate type, based on your JSON schema.
-
+These can be accessed using a subscript, and will return either an Optional LumaJSONObject or an object of the expected type if cast.
 
 Example:
 ```swift
@@ -40,19 +37,19 @@ if let parsed = luma.parse(jsonStr) {
     
     // Simple printing to the console to check JSON structure
     println(parsed)
-    
+
     // Simple Key/Value retreival
-    if let alertMessage = parsed["alert_message"]?.value as? String {
+    if let alertMessage = parsed["alert_message"] as? String {
         println("Alert: \(alertMessage)")
     }
     
     // Nested JSON
-    if let userName = parsed["user"]?["name"]?.value as? String {
+    if let userName = parsed["user"]?["name"] as? String {
         println("Username is \(userName)")
     }
     
     // Nested object casting works using Swift's built-in mechanisms
-    if let friendIDs = parsed["friend_ids"]?.value as? [Int] {
+    if let friendIDs = parsed["friend_ids"] as? [Int] {
         for friendID in friendIDs {
             println("Friend ID: \(friendID)")
         }


### PR DESCRIPTION
This allows access to `LumaJSONObject` values directly, without using `.value`:

``` swift
    if let userName = parsed["user"]?["name"] as? String {
        println("Username is \(userName)")
    }
```
- Updated example for no longer needing `.value`
